### PR TITLE
Updating configuration for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,21 @@
-language: java
+language: android
+#- echo yes | android update sdk -a -t tools,platform-tools,extra-android-support,extra-android-m2repository,android-19,build-tools-19.1.0,extra-google-google_play_services,extra-google-m2repository --force --no-ui
+android:
+   components:
+   - tools
+   - platform-tools
+   - android-19
+   - build-tools-20.0.0
+   - extra
 jdk: oraclejdk7
 
 before_install:
   # required libs for android build tools
   - sudo apt-get update
   - sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch
-  # for gradle output style
-  - export TERM=dumb
-  # newer version of gradle
-  - wget http://services.gradle.org/distributions/gradle-1.10-bin.zip
-  - unzip -qq gradle-1.10-bin.zip
-  - export GRADLE_HOME=$PWD/gradle-1.10
-  - export PATH=$GRADLE_HOME/bin:$PATH
-  - chmod +x gradlew
-  # just to test gradle version, against our provided one
-  - gradle -v
-  # newest Android SDK 22.3
-  - wget http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz
-  - tar -zxf android-sdk_r23.0.2-linux.tgz
-  - export ANDROID_HOME=`pwd`/android-sdk-linux
-  - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
   # Don't really need this (NDK stuff) for Android Bootstrap, but figured I'd leave it here for anyone who forks it. :)
   # newest Android NDK
   #- if [ `uname -m` = x86_64]; then wget http://dl.google.com/android/ndk/android-ndk-r9c-linux-x86_64.tar.bz2 -O ndk.tgz; else wget http://dl.google.com/android/ndk/android-ndk-r9c-linux-x86.tar.bz2 -O ndk.tgz; fi
   #- tar -xf ndk.tgz
   #- export ANDROID_NDK_HOME=`pwd`/android-ndk-r9c
   #- export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_NDK_HOME}
-  # manually set sdk.dir variable, according to local paths
-  - echo "sdk.dir=$ANDROID_HOME" > local.properties
-  - echo yes | android update sdk -a -t tools,platform-tools,extra-android-support,extra-android-m2repository,android-19,build-tools-19.1.0,extra-google-google_play_services,extra-google-m2repository --force --no-ui

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ android {
         // Exclude file to avoid
         // Error: Duplicate files during packaging of APK
         exclude 'META-INF/services/javax.annotation.processing.Processor'
+        exclude 'LICENSE.txt'
     }
 
     // signingConfigs {


### PR DESCRIPTION
Android has become a first-class citizen in Travis.
This update reflects this condition.

Deleting Android SDK step

Updating build-tools

Adding exclude license for avoiding Travis file duplication error